### PR TITLE
Implement auth flows and Redux store

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { UserState } from '../store/slices/userSlice';
+
+const API_BASE = '/api';
+
+interface Credentials {
+  phone: string;
+  password: string;
+}
+
+interface SignupData extends Credentials {
+  name: string;
+  location: string;
+}
+
+export async function login(creds: Credentials): Promise<UserState> {
+  const res = await axios.post(`${API_BASE}/login`, creds);
+  const { token, user } = res.data;
+  if (token) {
+    localStorage.setItem('token', token);
+  }
+  if (user) {
+    localStorage.setItem('user', JSON.stringify(user));
+  }
+  return user;
+}
+
+export async function signup(data: SignupData): Promise<void> {
+  await axios.post(`${API_BASE}/signup`, data);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { Provider } from 'react-redux'
 import './index.css'
 import './styles/main.scss';
 import App from './App.tsx'
+import { store } from './store'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>,
 )

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,14 +1,33 @@
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { login } from '../../api/auth';
+import { setUser } from '../../store/slices/userSlice';
+import type { AppDispatch } from '../../store';
 import './LoginPage.scss';
 import logo from '../../assets/logo.png';
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>();
+  const [form, setForm] = useState({ phone: '', password: '' });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: API login logic
+    try {
+      const user = await login(form);
+      dispatch(setUser(user));
+      navigate('/profile');
+    } catch (err) {
+      /* eslint no-console: off */
+      console.error(err);
+      alert('Login failed');
+    }
   };
 
   return (
@@ -26,12 +45,26 @@ const LoginPage = () => {
         <form onSubmit={handleSubmit}>
           <label>
             Phone Number
-            <input type="tel" placeholder="Enter your phone" required />
+            <input
+              type="tel"
+              name="phone"
+              placeholder="Enter your phone"
+              value={form.phone}
+              onChange={handleChange}
+              required
+            />
           </label>
 
           <label>
             Password
-            <input type="password" placeholder="Enter your password" required />
+            <input
+              type="password"
+              name="password"
+              placeholder="Enter your password"
+              value={form.password}
+              onChange={handleChange}
+              required
+            />
           </label>
 
           <motion.button

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import './SignupPage.scss';
 import logo from '../../assets/logo.png';
+import { signup } from '../../api/auth';
 
 const SignupPage = () => {
   const navigate = useNavigate();
@@ -17,11 +18,16 @@ const SignupPage = () => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // ✅ Normally send signup data to backend here
-    // 🚀 Redirect to OTP verification screen
-    navigate('/verify-otp', { state: { phone: form.phone } });
+    try {
+      await signup(form);
+      navigate('/login');
+    } catch (err) {
+      /* eslint no-console: off */
+      console.error(err);
+      alert('Signup failed');
+    }
   };
 
   return (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import userReducer from './slices/userSlice';
+import cartReducer from './slices/cartSlice';
+
+export const store = configureStore({
+  reducer: {
+    user: userReducer,
+    cart: cartReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface CartState {
+  items: CartItem[];
+}
+
+const initialState: CartState = {
+  items: [],
+};
+
+const cartSlice = createSlice({
+  name: 'cart',
+  initialState,
+  reducers: {
+    addToCart(state, action: PayloadAction<CartItem>) {
+      state.items.push(action.payload);
+    },
+    removeFromCart(state, action: PayloadAction<string>) {
+      state.items = state.items.filter((i) => i.id !== action.payload);
+    },
+    clearCart(state) {
+      state.items = [];
+    },
+  },
+});
+
+export const { addToCart, removeFromCart, clearCart } = cartSlice.actions;
+export default cartSlice.reducer;

--- a/src/store/slices/userSlice.ts
+++ b/src/store/slices/userSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface UserState {
+  name: string;
+  phone: string;
+  location: string;
+  role: string;
+  address?: string;
+}
+
+const initialState: UserState = {
+  name: '',
+  phone: '',
+  location: '',
+  role: 'user',
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    setUser(state, action: PayloadAction<UserState>) {
+      return { ...state, ...action.payload };
+    },
+    clearUser() {
+      return initialState;
+    },
+  },
+});
+
+export const { setUser, clearUser } = userSlice.actions;
+export default userSlice.reducer;


### PR DESCRIPTION
## Summary
- add Redux store with user and cart slices
- hook React to store in `main.tsx`
- implement login API interaction and state handling
- implement signup API call
- add basic auth service for API requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685650abf1348332822fe07533c422c7