### PR TITLE
Connect frontend auth to API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for backend API
+VITE_API_URL=http://localhost:3000/api

--- a/README.md
+++ b/README.md
@@ -52,4 +52,8 @@ export default tseslint.config({
   },
 })
 ```
+# Backend API configuration
+
+The frontend relies on a backend API defined by the `VITE_API_URL` environment variable. Copy `.env.example` to `.env` and adjust the URL to match your API server. All requests made through `src/api/client.ts` will use this base URL and automatically include the stored authentication token.
+
 # manacity-web

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,6 @@
-import axios from 'axios';
+import api from './client';
 import { UserState } from '../store/slices/userSlice';
 
-const API_BASE = '/api';
 
 interface Credentials {
   phone: string;
@@ -14,7 +13,7 @@ interface SignupData extends Credentials {
 }
 
 export async function login(creds: Credentials): Promise<UserState> {
-  const res = await axios.post(`${API_BASE}/login`, creds);
+  const res = await api.post('/login', creds);
   const { token, user } = res.data;
   if (token) {
     localStorage.setItem('token', token);
@@ -26,5 +25,5 @@ export async function login(creds: Credentials): Promise<UserState> {
 }
 
 export async function signup(data: SignupData): Promise<void> {
-  await axios.post(`${API_BASE}/signup`, data);
+  await api.post('/signup', data);
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '/api',
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- create axios client that uses `VITE_API_URL` and automatically attaches auth token
- use the new client in auth API calls
- document backend URL config in README and add `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68565e735ca083329d28dc42497f9996