### PR TITLE
Fix type-only imports for Redux slices

### DIFF
--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export interface CartItem {
   id: string;

--- a/src/store/slices/userSlice.ts
+++ b/src/store/slices/userSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export interface UserState {
   name: string;


### PR DESCRIPTION
## Summary
- fix PayloadAction import for cartSlice
- fix PayloadAction import for userSlice

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68567e0d7774833298dcef126bba705c