### PR TITLE
Fix type-only imports for UserState and RootState

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,5 @@
 import api from './client';
-import { UserState } from '../store/slices/userSlice';
+import type { UserState } from '../store/slices/userSlice';
 
 
 interface Credentials {

--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { RootState } from "../store";
+import type { RootState } from "../store";
 import {
   AiFillHome,
   AiOutlineShop,

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useSelector } from "react-redux";
-import { RootState } from "../../store";
+import type { RootState } from "../../store";
 import { motion } from "framer-motion";
 import "./Profile.scss";
 

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export interface CartItem {
   id: string;

--- a/src/store/slices/userSlice.ts
+++ b/src/store/slices/userSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export interface UserState {
   name: string;


### PR DESCRIPTION
## Summary
- use `import type` for UserState
- use `import type` for RootState in TabLayout and Profile components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68567e0d7774833298dcef126bba705c