### PR TITLE
Integrate backend API client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # Base URL for backend API
-VITE_API_URL=http://localhost:3000/api
+VITE_API_URL=https://manacity-latest-backend.onrender.com/api

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -27,3 +27,11 @@ export async function login(creds: Credentials): Promise<UserState> {
 export async function signup(data: SignupData): Promise<void> {
   await api.post('/signup', data);
 }
+
+export async function verifyOtp(phone: string, code: string): Promise<void> {
+  await api.post('/verify-otp', { phone, code });
+}
+
+export async function resendOtp(phone: string): Promise<void> {
+  await api.post('/resend-otp', { phone });
+}

--- a/src/pages/EventDetails/EventDetails.tsx
+++ b/src/pages/EventDetails/EventDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../../api/client";
 import "../EventDetails.scss";
 
 interface Event {
@@ -20,7 +20,7 @@ const EventDetails = () => {
   const [countdown, setCountdown] = useState<string>("");
 
   useEffect(() => {
-    axios.get(`/api/events/${id}`).then((res) => {
+    api.get(`/events/${id}`).then((res) => {
       setEvent(res.data);
       startCountdown(res.data.date);
     });

--- a/src/pages/OTPPage/OTPPage.tsx
+++ b/src/pages/OTPPage/OTPPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { verifyOtp, resendOtp as resendOtpApi } from '../../api/auth';
 import './OtpPage.scss';
 
 const OtpPage = () => {
@@ -20,17 +21,29 @@ const OtpPage = () => {
     }
   };
 
-  const handleVerify = () => {
+  const handleVerify = async () => {
     const code = otp.join('');
     if (code.length === 4) {
-      // TODO: Send OTP to server for verification
-      navigate('/profile'); // Example: Redirect to profile after verification
+      try {
+        await verifyOtp(phone, code);
+        navigate('/profile');
+      } catch (err) {
+        /* eslint no-console: off */
+        console.error(err);
+        alert('OTP verification failed');
+      }
     }
   };
 
-  const resendOtp = () => {
-    // TODO: Resend OTP to the phone number
-    alert(`OTP resent to ${phone}`);
+  const resendOtp = async () => {
+    try {
+      await resendOtpApi(phone);
+      alert(`OTP resent to ${phone}`);
+    } catch (err) {
+      /* eslint no-console: off */
+      console.error(err);
+      alert('Failed to resend OTP');
+    }
   };
 
   return (

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../../api/client";
 import "../ProductDetails.scss";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/cartSlice";
@@ -22,7 +22,7 @@ const ProductDetails = () => {
   const [product, setProduct] = useState<Product | null>(null);
 
   useEffect(() => {
-    axios.get(`/api/products/${id}`).then((res) => setProduct(res.data));
+    api.get(`/products/${id}`).then((res) => setProduct(res.data));
   }, [id]);
 
   if (!product) return <div className="product-details">Loading...</div>;

--- a/src/pages/ShopDetails/ShopDetails.tsx
+++ b/src/pages/ShopDetails/ShopDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/client";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
 import "../ShopDetails.scss";
@@ -30,7 +30,7 @@ const ShopDetails = () => {
   const [shop, setShop] = useState<Shop | null>(null);
 
   useEffect(() => {
-    axios.get(`/api/shops/${id}`).then((res) => setShop(res.data));
+    api.get(`/shops/${id}`).then((res) => setShop(res.data));
   }, [id]);
 
   if (!shop) return <div className="shop-details">Loading...</div>;

--- a/src/pages/Shops/Shops.tsx
+++ b/src/pages/Shops/Shops.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/client";
 import "../Shops.scss";
 
 interface Shop {
@@ -19,7 +19,7 @@ const Shops = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    axios.get("/api/shops").then((res) => setShops(res.data));
+    api.get("/shops").then((res) => setShops(res.data));
   }, []);
 
   const filteredShops = shops.filter((shop) => {

--- a/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
+++ b/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../../api/client";
 import "../VerifiedUserDetails.scss";
 
 interface VerifiedUser {
@@ -18,7 +18,7 @@ const VerifiedUserDetails = () => {
   const [user, setUser] = useState<VerifiedUser | null>(null);
 
   useEffect(() => {
-    axios.get(`/api/verified-users/${id}`).then((res) => setUser(res.data));
+    api.get(`/verified-users/${id}`).then((res) => setUser(res.data));
   }, [id]);
 
   if (!user) return <div className="verified-user-details">Loading...</div>;


### PR DESCRIPTION
## Summary
- add OTP verification helpers
- connect OTP page to backend
- use the shared API client across data pages
- set backend base URL for deployed server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68569d42bdac83329e16031161caf085