### PR TITLE
Implement auth guards and form validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,30 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import LandingPage from "./pages/LandingPage/LandingPage";
-import LoginPage from "./pages/LoginPage/LoginPage";
-import SignupPage from "./pages/SignupPage/SignupPage";
-import "./styles/main.scss";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import LandingPage from './pages/LandingPage/LandingPage';
+import LoginPage from './pages/LoginPage/LoginPage';
+import SignupPage from './pages/SignupPage/SignupPage';
+import ProtectedRoute from './components/ProtectedRoute';
+import './styles/main.scss';
 // import OtpPage from "./pages/OTPPage/OTPPage";
-import Profile from "./pages/Profile/Profile";
+import Profile from './pages/Profile/Profile';
+import { setUser } from './store/slices/userSlice';
+import type { AppDispatch } from './store';
 
 function App() {
+  const dispatch = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      try {
+        dispatch(setUser(JSON.parse(stored)));
+      } catch {
+        // ignore parsing errors
+      }
+    }
+  }, [dispatch]);
+
   return (
     <BrowserRouter>
       <Routes>
@@ -14,7 +32,9 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
         {/* <Route path="/verify-otp" element={<OtpPage />} /> */}
-        <Route path="/profile" element={<Profile />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/profile" element={<Profile />} />
+        </Route>
         {/* <Route path="/verified-users" element={<VerifiedUsers />} /> */}
         {/* <Route path="/special-shop" element={<SpecialShop />} /> */}
       </Routes>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRoute = () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/pages/LoginPage/LoginPage.scss
+++ b/src/pages/LoginPage/LoginPage.scss
@@ -55,6 +55,17 @@
         }
       }
 
+      .error {
+        color: red;
+        font-size: 0.85rem;
+        margin-top: 0.25rem;
+        display: block;
+      }
+
+      .error.general {
+        text-align: center;
+      }
+
       .login-btn {
         @include button-style($primary-color, #fff);
         width: 100%;

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -12,6 +12,7 @@ const LoginPage = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const [form, setForm] = useState({ phone: '', password: '' });
+  const [errors, setErrors] = useState<{ phone?: string; password?: string; general?: string }>({});
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -19,14 +20,32 @@ const LoginPage = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    const newErrors: { phone?: string; password?: string } = {};
+    if (!/^\d{10,}$/.test(form.phone)) {
+      newErrors.phone = 'Enter a valid phone number';
+    }
+    if (form.password.length < 6) {
+      newErrors.password = 'Password must be at least 6 characters';
+    }
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     try {
       const user = await login(form);
       dispatch(setUser(user));
       navigate('/profile');
-    } catch (err) {
+    } catch (err: any) {
       /* eslint no-console: off */
       console.error(err);
-      alert('Login failed');
+      const data = err.response?.data;
+      const fieldErrors = data?.errors;
+      if (fieldErrors && typeof fieldErrors === 'object') {
+        setErrors(fieldErrors);
+      } else {
+        const message = data?.message || 'Login failed';
+        setErrors({ general: message });
+      }
     }
   };
 
@@ -53,6 +72,7 @@ const LoginPage = () => {
               onChange={handleChange}
               required
             />
+            {errors.phone && <span className="error">{errors.phone}</span>}
           </label>
 
           <label>
@@ -65,7 +85,10 @@ const LoginPage = () => {
               onChange={handleChange}
               required
             />
+            {errors.password && <span className="error">{errors.password}</span>}
           </label>
+
+          {errors.general && <div className="error general">{errors.general}</div>}
 
           <motion.button
             type="submit"

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -55,6 +55,17 @@
         }
       }
 
+      .error {
+        color: red;
+        font-size: 0.85rem;
+        margin-top: 0.25rem;
+        display: block;
+      }
+
+      .error.general {
+        text-align: center;
+      }
+
       .signup-btn {
         @include button-style($primary-color, #fff);
         width: 100%;

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -13,6 +13,7 @@ const SignupPage = () => {
     password: '',
     location: '',
   });
+  const [errors, setErrors] = useState<{ name?: string; phone?: string; password?: string; location?: string; general?: string }>({});
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -20,13 +21,28 @@ const SignupPage = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const newErrors: { name?: string; phone?: string; password?: string; location?: string } = {};
+    if (!form.name.trim()) newErrors.name = 'Name is required';
+    if (!/^\d{10,}$/.test(form.phone)) newErrors.phone = 'Enter a valid phone number';
+    if (form.password.length < 6) newErrors.password = 'Password must be at least 6 characters';
+    if (!form.location) newErrors.location = 'Location is required';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     try {
       await signup(form);
       navigate('/login');
-    } catch (err) {
+    } catch (err: any) {
       /* eslint no-console: off */
       console.error(err);
-      alert('Signup failed');
+      const data = err.response?.data;
+      const fieldErrors = data?.errors;
+      if (fieldErrors && typeof fieldErrors === 'object') {
+        setErrors(fieldErrors);
+      } else {
+        const message = data?.message || 'Signup failed';
+        setErrors({ general: message });
+      }
     }
   };
 
@@ -45,16 +61,19 @@ const SignupPage = () => {
           <label>
             Name
             <input type="text" name="name" required value={form.name} onChange={handleChange} />
+            {errors.name && <span className="error">{errors.name}</span>}
           </label>
 
           <label>
             Phone Number
             <input type="tel" name="phone" required value={form.phone} onChange={handleChange} />
+            {errors.phone && <span className="error">{errors.phone}</span>}
           </label>
 
           <label>
             Password
             <input type="password" name="password" required value={form.password} onChange={handleChange} />
+            {errors.password && <span className="error">{errors.password}</span>}
           </label>
 
           <label>
@@ -66,7 +85,10 @@ const SignupPage = () => {
               <option value="North Market">North Market</option>
               <option value="Old Street">Old Street</option>
             </select>
+            {errors.location && <span className="error">{errors.location}</span>}
           </label>
+
+          {errors.general && <div className="error general">{errors.general}</div>}
 
           <motion.button
             type="submit"


### PR DESCRIPTION
## Summary
- load stored user into Redux and guard protected pages
- validate login/signup forms and display errors
- add global error styling in forms
- create `ProtectedRoute` for auth-protected navigation
- handle API errors per field so users know exactly what went wrong

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856a27786888332a75d50a0d2bf5f43