### PR TITLE
Configure API base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Base URL for backend API
+VITE_API_URL=https://manacity-latest-backend.onrender.com/api

--- a/README.md
+++ b/README.md
@@ -56,4 +56,6 @@ export default tseslint.config({
 
 The frontend relies on a backend API defined by the `VITE_API_URL` environment variable. Copy `.env.example` to `.env` and adjust the URL to match your API server. All requests made through `src/api/client.ts` will use this base URL and automatically include the stored authentication token.
 
+Authentication endpoints are prefixed with `/auth`, so login, signup and related actions will request URLs like `${VITE_API_URL}/auth/login`.
+
 # manacity-web

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -13,7 +13,7 @@ interface SignupData extends Credentials {
 }
 
 export async function login(creds: Credentials): Promise<UserState> {
-  const res = await api.post('/login', creds);
+  const res = await api.post('/auth/login', creds);
   const { token, user } = res.data;
   if (token) {
     localStorage.setItem('token', token);
@@ -25,13 +25,13 @@ export async function login(creds: Credentials): Promise<UserState> {
 }
 
 export async function signup(data: SignupData): Promise<void> {
-  await api.post('/signup', data);
+  await api.post('/auth/signup', data);
 }
 
 export async function verifyOtp(phone: string, code: string): Promise<void> {
-  await api.post('/verify-otp', { phone, code });
+  await api.post('/auth/verify-otp', { phone, code });
 }
 
 export async function resendOtp(phone: string): Promise<void> {
-  await api.post('/resend-otp', { phone });
+  await api.post('/auth/resend-otp', { phone });
 }


### PR DESCRIPTION
## Summary
- create `.env` with backend API URL so requests are sent to the correct server
- use `/auth` prefix in auth API functions
- document the `/auth` prefix

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_685a837227f08332ac193e336c53328b