### PR TITLE
Add frontend fallback sample data

### DIFF
--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -1,0 +1,56 @@
+export const sampleShops = [
+  {
+    _id: 'shop1',
+    name: 'Star Electronics',
+    category: 'Electronics',
+    location: 'Town Center',
+    address: '123 Market Street',
+    image: 'https://source.unsplash.com/400x300/?electronics-shop',
+    products: [
+      {
+        _id: 'prod1',
+        name: 'LED TV',
+        price: 12000,
+        image: 'https://source.unsplash.com/300x200/?tv',
+      },
+      {
+        _id: 'prod2',
+        name: 'Bluetooth Speaker',
+        price: 3500,
+        image: 'https://source.unsplash.com/300x200/?speaker',
+      },
+    ],
+  },
+];
+
+export const sampleProduct = {
+  _id: 'prod1',
+  name: 'Sample Product',
+  image: 'https://source.unsplash.com/600x300/?product',
+  price: 999,
+  description: 'This is a placeholder product description.',
+  category: 'General',
+  shopName: 'Star Electronics',
+  discount: 10,
+};
+
+export const sampleVerifiedUser = {
+  _id: 'user1',
+  name: 'Jane Doe',
+  profession: 'Electrician',
+  bio: 'Experienced electrician providing quality services.',
+  location: 'Town Center',
+  contact: '1234567890',
+  avatar: 'https://source.unsplash.com/300x200/?portrait',
+};
+
+export const sampleEvent = {
+  _id: 'event1',
+  name: 'Community Cricket Match',
+  category: 'Sports',
+  location: 'City Stadium',
+  date: '2025-08-01',
+  description: 'Join us for an exciting community cricket event!',
+  adminNote: 'Registration closes a week before the event.',
+  image: 'https://source.unsplash.com/600x300/?cricket',
+};

--- a/src/pages/EventDetails/EventDetails.tsx
+++ b/src/pages/EventDetails/EventDetails.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
+import { sampleEvent } from "../../data/sampleData";
 import "./EventDetails.scss";
 
 interface Event {
@@ -20,10 +21,21 @@ const EventDetails = () => {
   const [countdown, setCountdown] = useState<string>("");
 
   useEffect(() => {
-    api.get(`/events/${id}`).then((res) => {
-      setEvent(res.data);
-      startCountdown(res.data.date);
-    });
+    api
+      .get(`/events/${id}`)
+      .then((res) => {
+        if (res.data) {
+          setEvent(res.data);
+          startCountdown(res.data.date);
+        } else {
+          setEvent(sampleEvent);
+          startCountdown(sampleEvent.date);
+        }
+      })
+      .catch(() => {
+        setEvent(sampleEvent);
+        startCountdown(sampleEvent.date);
+      });
   }, [id]);
 
   const startCountdown = (eventDate: string) => {

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
+import { sampleProduct } from "../../data/sampleData";
 import "./ProductDetails.scss";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
@@ -22,7 +23,16 @@ const ProductDetails = () => {
   const [product, setProduct] = useState<Product | null>(null);
 
   useEffect(() => {
-    api.get(`/products/${id}`).then((res) => setProduct(res.data));
+    api
+      .get(`/products/${id}`)
+      .then((res) => {
+        if (res.data) {
+          setProduct(res.data);
+        } else {
+          setProduct(sampleProduct);
+        }
+      })
+      .catch(() => setProduct(sampleProduct));
   }, [id]);
 
   if (!product) return <div className="product-details">Loading...</div>;

--- a/src/pages/ShopDetails/ShopDetails.tsx
+++ b/src/pages/ShopDetails/ShopDetails.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import api from "../../api/client";
+import { sampleShops } from "../../data/sampleData";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
 import "./ShopDetails.scss";
@@ -30,7 +31,16 @@ const ShopDetails = () => {
   const [shop, setShop] = useState<Shop | null>(null);
 
   useEffect(() => {
-    api.get(`/shops/${id}`).then((res) => setShop(res.data));
+    api
+      .get(`/shops/${id}`)
+      .then((res) => {
+        if (res.data) {
+          setShop(res.data);
+        } else {
+          setShop(sampleShops[0]);
+        }
+      })
+      .catch(() => setShop(sampleShops[0]));
   }, [id]);
 
   if (!shop) return <div className="shop-details">Loading...</div>;

--- a/src/pages/Shops/Shops.tsx
+++ b/src/pages/Shops/Shops.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
+import { sampleShops } from "../../data/sampleData";
 import "./Shops.scss";
 
 interface Shop {
@@ -19,7 +20,16 @@ const Shops = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    api.get("/shops").then((res) => setShops(res.data));
+    api
+      .get("/shops")
+      .then((res) => {
+        if (Array.isArray(res.data) && res.data.length > 0) {
+          setShops(res.data);
+        } else {
+          setShops(sampleShops);
+        }
+      })
+      .catch(() => setShops(sampleShops));
   }, []);
 
   const filteredShops = shops.filter((shop) => {

--- a/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
+++ b/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
+import { sampleVerifiedUser } from "../../data/sampleData";
 import "./VerifiedUserDetails.scss";
 
 interface VerifiedUser {
@@ -18,7 +19,16 @@ const VerifiedUserDetails = () => {
   const [user, setUser] = useState<VerifiedUser | null>(null);
 
   useEffect(() => {
-    api.get(`/verified-users/${id}`).then((res) => setUser(res.data));
+    api
+      .get(`/verified-users/${id}`)
+      .then((res) => {
+        if (res.data) {
+          setUser(res.data);
+        } else {
+          setUser(sampleVerifiedUser);
+        }
+      })
+      .catch(() => setUser(sampleVerifiedUser));
   }, [id]);
 
   if (!user) return <div className="verified-user-details">Loading...</div>;


### PR DESCRIPTION
## Summary
- add `sampleData.ts` with example shops, products, users and events
- use the sample data in shop, product, event and verified user pages when API calls return nothing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e4630cda483328a734abf9a2a1596