### PR TITLE
Add shimmer loading placeholders

### DIFF
--- a/src/components/Shimmer.scss
+++ b/src/components/Shimmer.scss
@@ -1,0 +1,27 @@
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.shimmer {
+  position: relative;
+  overflow: hidden;
+  background-color: #f0f0f0;
+}
+
+.shimmer::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  animation: shimmer 1.2s infinite;
+}

--- a/src/components/Shimmer.tsx
+++ b/src/components/Shimmer.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './Shimmer.scss';
+
+interface ShimmerProps {
+  width?: string | number;
+  height?: string | number;
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+const Shimmer: React.FC<ShimmerProps> = ({ width, height, style, className = '' }) => {
+  return (
+    <div
+      className={`shimmer ${className}`.trim()}
+      style={{ width, height, ...style }}
+    />
+  );
+};
+
+export default Shimmer;

--- a/src/pages/EventDetails/EventDetails.tsx
+++ b/src/pages/EventDetails/EventDetails.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
 import { sampleEvent } from "../../data/sampleData";
+import Shimmer from "../../components/Shimmer";
 import "./EventDetails.scss";
 
 interface Event {
@@ -19,6 +20,7 @@ interface Event {
 const EventDetails = () => {
   const { id } = useParams();
   const [event, setEvent] = useState<Event | null>(null);
+  const [loading, setLoading] = useState(true);
   const [countdown, setCountdown] = useState<string>("");
   const [leaderboard, setLeaderboard] = useState<Array<{ userId: string; name: string; score: number }>>([]);
   const [registered, setRegistered] = useState(false);
@@ -39,7 +41,8 @@ const EventDetails = () => {
       .catch(() => {
         setEvent(sampleEvent);
         startCountdown(sampleEvent.startDate || sampleEvent.date);
-      });
+      })
+      .finally(() => setLoading(false));
 
     api
       .get(`/events/${id}/leaderboard`)
@@ -74,7 +77,18 @@ const EventDetails = () => {
       .catch(() => setMessage("Registration failed"));
   };
 
-  if (!event) return <div className="event-details">Loading...</div>;
+  if (loading || !event)
+    return (
+      <div className="event-details">
+        <Shimmer style={{ width: "100%", height: 300 }} className="rounded" />
+        <div className="info">
+          <Shimmer style={{ height: 32, width: "60%", margin: "1rem auto" }} />
+          <Shimmer style={{ height: 20, width: "40%", marginBottom: 16 }} />
+          <Shimmer style={{ height: 20, width: "40%", marginBottom: 16 }} />
+          <Shimmer style={{ height: 60, width: "100%" }} />
+        </div>
+      </div>
+    );
 
   return (
     <div className="event-details">

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
 import { sampleProduct } from "../../data/sampleData";
+import Shimmer from "../../components/Shimmer";
 import "./ProductDetails.scss";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
@@ -21,6 +22,7 @@ const ProductDetails = () => {
   const { id } = useParams();
   const dispatch = useDispatch();
   const [product, setProduct] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     api
@@ -31,11 +33,26 @@ const ProductDetails = () => {
         } else {
           setProduct(sampleProduct);
         }
+        setLoading(false);
       })
-      .catch(() => setProduct(sampleProduct));
+      .catch(() => {
+        setProduct(sampleProduct);
+        setLoading(false);
+      });
   }, [id]);
 
-  if (!product) return <div className="product-details">Loading...</div>;
+  if (loading || !product)
+    return (
+      <div className="product-details">
+        <Shimmer style={{ width: "100%", height: 300 }} className="rounded" />
+        <div className="info">
+          <Shimmer style={{ height: 32, width: "60%", margin: "1rem auto" }} />
+          <Shimmer style={{ height: 20, width: "40%", margin: "0 auto" }} />
+          <Shimmer style={{ height: 24, width: "30%", margin: "1rem auto" }} />
+          <Shimmer style={{ height: 80, width: "100%", marginTop: 16 }} />
+        </div>
+      </div>
+    );
 
   return (
     <div className="product-details">

--- a/src/pages/ShopDetails/ShopDetails.tsx
+++ b/src/pages/ShopDetails/ShopDetails.tsx
@@ -4,6 +4,7 @@ import api from "../../api/client";
 import { sampleShops } from "../../data/sampleData";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
+import Shimmer from "../../components/Shimmer";
 import "./ShopDetails.scss";
 
 interface Product {
@@ -29,6 +30,7 @@ const ShopDetails = () => {
   const dispatch = useDispatch();
 
   const [shop, setShop] = useState<Shop | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     api
@@ -39,11 +41,36 @@ const ShopDetails = () => {
         } else {
           setShop(sampleShops[0]);
         }
+        setLoading(false);
       })
-      .catch(() => setShop(sampleShops[0]));
+      .catch(() => {
+        setShop(sampleShops[0]);
+        setLoading(false);
+      });
   }, [id]);
 
-  if (!shop) return <div className="shop-details">Loading...</div>;
+  if (loading || !shop)
+    return (
+      <div className="shop-details">
+        <div className="header">
+          <Shimmer style={{ width: "100%", height: 250 }} className="rounded" />
+          <div className="info">
+            <Shimmer style={{ height: 24, width: "60%", margin: "0.5rem auto" }} />
+            <Shimmer style={{ height: 16, width: "40%" }} />
+          </div>
+        </div>
+        <h3 className="section-title">Products</h3>
+        <div className="product-list">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="product-card">
+              <Shimmer className="rounded" style={{ height: 120 }} />
+              <Shimmer style={{ height: 16, marginTop: 8 }} />
+              <Shimmer style={{ height: 16, width: "50%", marginBottom: 8 }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
 
   return (
     <div className="shop-details">

--- a/src/pages/Shops/Shops.tsx
+++ b/src/pages/Shops/Shops.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import { sampleShops } from "../../data/sampleData";
+import Shimmer from "../../components/Shimmer";
 import "./Shops.scss";
 
 interface Shop {
@@ -14,6 +15,7 @@ interface Shop {
 
 const Shops = () => {
   const [shops, setShops] = useState<Shop[]>([]);
+  const [loading, setLoading] = useState(true);
   const [category, setCategory] = useState("");
   const [location, setLocation] = useState("");
   const [search, setSearch] = useState("");
@@ -28,8 +30,12 @@ const Shops = () => {
         } else {
           setShops(sampleShops);
         }
+        setLoading(false);
       })
-      .catch(() => setShops(sampleShops));
+      .catch(() => {
+        setShops(sampleShops);
+        setLoading(false);
+      });
   }, []);
 
   const filteredShops = shops.filter((shop) => {
@@ -68,21 +74,29 @@ const Shops = () => {
       </div>
 
       <div className="shop-list">
-        {filteredShops.map((shop) => (
-          <div
-            key={shop._id}
-            className="shop-card"
-            onClick={() => navigate(`/shops/${shop._id}`)}
-          >
-            <img
-              src={shop.image || "https://via.placeholder.com/150"}
-              alt={shop.name}
-            />
-            <h3>{shop.name}</h3>
-            <p>{shop.category}</p>
-            <p>{shop.location}</p>
-          </div>
-        ))}
+        {loading
+          ? Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="shop-card">
+                <Shimmer className="rounded" style={{ height: 140 }} />
+                <Shimmer style={{ height: 16, marginTop: 8 }} />
+                <Shimmer style={{ height: 16, width: "60%" }} />
+              </div>
+            ))
+          : filteredShops.map((shop) => (
+              <div
+                key={shop._id}
+                className="shop-card"
+                onClick={() => navigate(`/shops/${shop._id}`)}
+              >
+                <img
+                  src={shop.image || "https://via.placeholder.com/150"}
+                  alt={shop.name}
+                />
+                <h3>{shop.name}</h3>
+                <p>{shop.category}</p>
+                <p>{shop.location}</p>
+              </div>
+            ))}
       </div>
     </div>
   );

--- a/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
+++ b/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import api from "../../api/client";
 import { sampleVerifiedUser } from "../../data/sampleData";
+import Shimmer from "../../components/Shimmer";
 import "./VerifiedUserDetails.scss";
 
 interface VerifiedUser {
@@ -17,6 +18,7 @@ interface VerifiedUser {
 const VerifiedUserDetails = () => {
   const { id } = useParams();
   const [user, setUser] = useState<VerifiedUser | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     api
@@ -27,11 +29,30 @@ const VerifiedUserDetails = () => {
         } else {
           setUser(sampleVerifiedUser);
         }
+        setLoading(false);
       })
-      .catch(() => setUser(sampleVerifiedUser));
+      .catch(() => {
+        setUser(sampleVerifiedUser);
+        setLoading(false);
+      });
   }, [id]);
 
-  if (!user) return <div className="verified-user-details">Loading...</div>;
+  if (loading || !user)
+    return (
+      <div className="verified-user-details">
+        <div className="header">
+          <Shimmer className="rounded" style={{ width: 120, height: 120 }} />
+          <div className="info">
+            <Shimmer style={{ height: 20, width: "60%", marginBottom: 8 }} />
+            <Shimmer style={{ height: 16, width: "40%" }} />
+          </div>
+        </div>
+        <div className="bio" style={{ marginTop: '2rem' }}>
+          <Shimmer style={{ height: 16, width: "80%", marginBottom: 6 }} />
+          <Shimmer style={{ height: 16, width: "90%" }} />
+        </div>
+      </div>
+    );
 
   return (
     <div className="verified-user-details">

--- a/src/pages/VerifiedUsers/VerifiedUsers.tsx
+++ b/src/pages/VerifiedUsers/VerifiedUsers.tsx
@@ -11,8 +11,11 @@ interface VerifiedUser {
   image?: string;
 }
 
+import Shimmer from "../../components/Shimmer";
+
 const VerifiedUsers = () => {
   const [users, setUsers] = useState<VerifiedUser[]>([]);
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,31 +27,42 @@ const VerifiedUsers = () => {
         } else {
           setUsers(sampleVerifiedUsers);
         }
+        setLoading(false);
       })
-      .catch(() => setUsers(sampleVerifiedUsers));
+      .catch(() => {
+        setUsers(sampleVerifiedUsers);
+        setLoading(false);
+      });
   }, []);
 
   return (
     <div className="verified-users">
       <h2>Verified Users</h2>
       <div className="user-list">
-        {users.map((user) => (
-          <div
-            key={user._id}
-            className="user-card"
-            onClick={() => navigate(`/verified-users/${user._id}`)}
-          >
-            <img
-              src={
-                user.image ||
-                `https://ui-avatars.com/api/?name=${user.name}&background=random`
-              }
-              alt={user.name}
-            />
-            <h3>{user.name}</h3>
-            {user.profession && <p>{user.profession}</p>}
-          </div>
-        ))}
+        {loading
+          ? Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="user-card">
+                <Shimmer className="rounded" style={{ height: 140 }} />
+                <Shimmer style={{ height: 16, marginTop: 8, width: "60%" }} />
+              </div>
+            ))
+          : users.map((user) => (
+              <div
+                key={user._id}
+                className="user-card"
+                onClick={() => navigate(`/verified-users/${user._id}`)}
+              >
+                <img
+                  src={
+                    user.image ||
+                    `https://ui-avatars.com/api/?name=${user.name}&background=random`
+                  }
+                  alt={user.name}
+                />
+                <h3>{user.name}</h3>
+                {user.profession && <p>{user.profession}</p>}
+              </div>
+            ))}
       </div>
     </div>
   );

--- a/src/styles/_shimmer.scss
+++ b/src/styles/_shimmer.scss
@@ -1,0 +1,6 @@
+@import '../components/Shimmer.scss';
+
+// Additional utility classes
+.shimmer.rounded {
+  border-radius: 8px;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,7 @@
 @import "./variables";
 @import "./mixins";
 @import "./base";
+@import "./shimmer";
 
 html,
 body,


### PR DESCRIPTION
## Summary
- create reusable `Shimmer` component with animated gradient
- import shimmer styles globally
- show shimmer placeholders for detail pages and lists while API data loads

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e4f31ccc883328ab325f8464a1d39