### PR TITLE
Add global fallback image

### DIFF
--- a/src/assets/no-image.svg
+++ b/src/assets/no-image.svg
@@ -1,0 +1,4 @@
+<svg width="150" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#ccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="20">No Image</text>
+</svg>

--- a/src/pages/EventDetails/EventDetails.tsx
+++ b/src/pages/EventDetails/EventDetails.tsx
@@ -4,6 +4,7 @@ import api from "../../api/client";
 import { sampleEvent } from "../../data/sampleData";
 import Shimmer from "../../components/Shimmer";
 import "./EventDetails.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface Event {
   _id: string;
@@ -96,6 +97,7 @@ const EventDetails = () => {
         src={event.image || "https://via.placeholder.com/600x300?text=Event"}
         alt={event.name}
         className="event-img"
+        onError={(e) => (e.currentTarget.src = fallbackImage)}
       />
       <div className="info">
         <h1>{event.name}</h1>

--- a/src/pages/Events/Events.tsx
+++ b/src/pages/Events/Events.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import { sampleEvents } from "../../data/sampleHomeData";
 import "./Events.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface EventItem {
   _id: string;
@@ -56,6 +57,7 @@ const Events = () => {
               <img
                 src={ev.banner || ev.image || "https://via.placeholder.com/300x200?text=Event"}
                 alt={ev.title || ev.name}
+                onError={(e) => (e.currentTarget.src = fallbackImage)}
               />
               <h3>{ev.title || ev.name}</h3>
               {ev.category && <p className="cat">{ev.category}</p>}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -9,6 +9,7 @@ import {
   sampleSpecialProducts,
   banner,
 } from "../../data/sampleHomeData";
+import fallbackImage from "../../assets/no-image.svg";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -36,7 +37,7 @@ const Home = () => {
         transition={{ duration: 0.6 }}
         onClick={() => banner.link && navigate(banner.link)}
       >
-        <img src={banner.image} alt="Admin Update" />
+        <img src={banner.image} alt="Admin Update" onError={(e) => (e.currentTarget.src = fallbackImage)} />
         <div className="banner-text">
           <h3>{banner.title}</h3>
           <p>{banner.subtitle}</p>
@@ -95,7 +96,7 @@ const Section = ({ title, data, type, navigate, settings }: any) => (
             )
           }
         >
-          <img src={item.image} alt={item.name || item.title} />
+          <img src={item.image} alt={item.name || item.title} onError={(e) => (e.currentTarget.src = fallbackImage)} />
           <div className="card-info">
             <h4>{item.name || item.title}</h4>
             {type === "event" && (

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import "./LandingPage.scss";
 import logo from "../../assets/logo.png"; // ✅ using logo from src/assets
+import fallbackImage from "../../assets/no-image.svg";
 
 const LandingPage = () => {
   const navigate = useNavigate();
@@ -14,7 +15,7 @@ const LandingPage = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.7, ease: "easeOut" }}
       >
-        <img src={logo} alt="Manacity Logo" className="logo" />
+        <img src={logo} alt="Manacity Logo" className="logo" onError={(e) => (e.currentTarget.src = fallbackImage)} />
 
         <h1>
           Welcome to <span>Manacity</span>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -7,6 +7,7 @@ import { setUser } from '../../store/slices/userSlice';
 import type { AppDispatch } from '../../store';
 import './LoginPage.scss';
 import logo from '../../assets/logo.png';
+import fallbackImage from '../../assets/no-image.svg';
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -57,7 +58,7 @@ const LoginPage = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.7, ease: 'easeOut' }}
       >
-        <img src={logo} alt="Manacity Logo" className="logo" />
+        <img src={logo} alt="Manacity Logo" className="logo" onError={(e) => (e.currentTarget.src = fallbackImage)} />
 
         <h2>Login to Your Account</h2>
 

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -6,6 +6,7 @@ import Shimmer from "../../components/Shimmer";
 import "./ProductDetails.scss";
 import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface Product {
   _id: string;
@@ -62,6 +63,7 @@ const ProductDetails = () => {
         }
         alt={product.name}
         className="product-img"
+        onError={(e) => (e.currentTarget.src = fallbackImage)}
       />
 
       <div className="info">

--- a/src/pages/ShopDetails/ShopDetails.tsx
+++ b/src/pages/ShopDetails/ShopDetails.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 import { addToCart } from "../../store/slices/cartSlice";
 import Shimmer from "../../components/Shimmer";
 import "./ShopDetails.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface Product {
   _id: string;
@@ -78,6 +79,7 @@ const ShopDetails = () => {
         <img
           src={shop.image || "https://via.placeholder.com/500x250"}
           alt={shop.name}
+          onError={(e) => (e.currentTarget.src = fallbackImage)}
         />
         <div className="info">
           <h2>{shop.name}</h2>
@@ -94,6 +96,7 @@ const ShopDetails = () => {
             <img
               src={product.image || "https://via.placeholder.com/200"}
               alt={product.name}
+              onError={(e) => (e.currentTarget.src = fallbackImage)}
             />
             <h4>{product.name}</h4>
             <p>₹{product.price}</p>

--- a/src/pages/Shops/Shops.tsx
+++ b/src/pages/Shops/Shops.tsx
@@ -4,6 +4,7 @@ import api from "../../api/client";
 import { sampleShops } from "../../data/sampleData";
 import Shimmer from "../../components/Shimmer";
 import "./Shops.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface Shop {
   _id: string;
@@ -91,6 +92,7 @@ const Shops = () => {
                 <img
                   src={shop.image || "https://via.placeholder.com/150"}
                   alt={shop.name}
+                  onError={(e) => (e.currentTarget.src = fallbackImage)}
                 />
                 <h3>{shop.name}</h3>
                 <p>{shop.category}</p>

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import './SignupPage.scss';
 import logo from '../../assets/logo.png';
+import fallbackImage from '../../assets/no-image.svg';
 import { signup } from '../../api/auth';
 
 const SignupPage = () => {
@@ -53,7 +54,7 @@ const SignupPage = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.7 }}
       >
-        <img src={logo} alt="Manacity Logo" className="logo" />
+        <img src={logo} alt="Manacity Logo" className="logo" onError={(e) => (e.currentTarget.src = fallbackImage)} />
         <h2>Create Your Account</h2>
 
         <form onSubmit={handleSubmit}>

--- a/src/pages/SpecialShop/SpecialShop.tsx
+++ b/src/pages/SpecialShop/SpecialShop.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import { sampleSpecialProducts } from "../../data/sampleHomeData";
 import "./SpecialShop.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface Product {
   _id: string;
@@ -40,6 +41,7 @@ const SpecialShop = () => {
             <img
               src={product.image || "https://via.placeholder.com/200"}
               alt={product.name}
+              onError={(e) => (e.currentTarget.src = fallbackImage)}
             />
             <h3>{product.name}</h3>
           </div>

--- a/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
+++ b/src/pages/VerifiedUserDetails/VerifiedUserDetails.tsx
@@ -4,6 +4,7 @@ import api from "../../api/client";
 import { sampleVerifiedUser } from "../../data/sampleData";
 import Shimmer from "../../components/Shimmer";
 import "./VerifiedUserDetails.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface VerifiedUser {
   _id: string;
@@ -63,6 +64,7 @@ const VerifiedUserDetails = () => {
             `https://ui-avatars.com/api/?name=${user.name}&background=random`
           }
           alt={user.name}
+          onError={(e) => (e.currentTarget.src = fallbackImage)}
         />
         <div className="info">
           <h2>{user.name}</h2>

--- a/src/pages/VerifiedUsers/VerifiedUsers.tsx
+++ b/src/pages/VerifiedUsers/VerifiedUsers.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import api from "../../api/client";
 import { sampleVerifiedUsers } from "../../data/sampleHomeData";
 import "./VerifiedUsers.scss";
+import fallbackImage from "../../assets/no-image.svg";
 
 interface VerifiedUser {
   _id: string;
@@ -58,6 +59,7 @@ const VerifiedUsers = () => {
                     `https://ui-avatars.com/api/?name=${user.name}&background=random`
                   }
                   alt={user.name}
+                  onError={(e) => (e.currentTarget.src = fallbackImage)}
                 />
                 <h3>{user.name}</h3>
                 {user.profession && <p>{user.profession}</p>}


### PR DESCRIPTION
## Summary
- add new `no-image.svg` asset
- apply `onError` fallbacks to all `<img>` tags across pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e532f1a488332bb25d8111d468292