### PR TITLE
Add global fallback for images

### DIFF
--- a/src/pages/Events/Events.tsx
+++ b/src/pages/Events/Events.tsx
@@ -68,6 +68,7 @@ const Events = () => {
                   <img
                     src={ev.banner || ev.image || "https://via.placeholder.com/300x200?text=Event"}
                     alt={ev.title || ev.name}
+                    onError={(e) => (e.currentTarget.src = fallbackImage)}
                   />
                   <h3>{ev.title || ev.name}</h3>
                   {ev.category && <p className="cat">{ev.category}</p>}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -169,7 +169,11 @@ const Section = ({ title, data, type, navigate, settings, loading }: SectionProp
             </>
           ) : (
             <>
-              <img src={item.image} alt={item.name || item.title} />
+              <img
+                src={item.image}
+                alt={item.name || item.title}
+                onError={(e) => (e.currentTarget.src = fallbackImage)}
+              />
               <div className="card-info">
                 <h4>{item.name || item.title}</h4>
                 {type === "event" && (

--- a/src/pages/SpecialShop/SpecialShop.tsx
+++ b/src/pages/SpecialShop/SpecialShop.tsx
@@ -51,6 +51,7 @@ const SpecialShop = () => {
                 <img
                   src={product.image || "https://via.placeholder.com/200"}
                   alt={product.name}
+                  onError={(e) => (e.currentTarget.src = fallbackImage)}
                 />
                 <h3>{product.name}</h3>
               </div>


### PR DESCRIPTION
## Summary
- ensure slider product images have fallback
- ensure special shop product images have fallback
- ensure event images have fallback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e5ac2bde08332b869fa763e7b686d