### PR TITLE
Enhance responsive layouts

### DIFF
--- a/src/layouts/TabLayout.scss
+++ b/src/layouts/TabLayout.scss
@@ -1,3 +1,5 @@
+@import "../styles/mixins";
+
 .tab-layout {
   display: flex;
   flex-direction: column;
@@ -70,6 +72,44 @@
       font-size: 0.75rem;
       padding: 2px 6px;
       border-radius: 999px;
+    }
+  }
+
+  @include respond(md) {
+    flex-direction: row;
+
+    .tab-content {
+      padding-bottom: 0;
+    }
+
+    .tab-bar {
+      position: sticky;
+      top: 0;
+      bottom: auto;
+      width: 220px;
+      height: 100vh;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+      border-top: none;
+      border-right: 1px solid #ddd;
+      padding: 1rem 0;
+
+      button {
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        width: 100%;
+
+        svg {
+          font-size: 1.2rem;
+        }
+
+        span {
+          display: inline;
+        }
+      }
     }
   }
 }

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -1,5 +1,15 @@
+@import "../../styles/mixins";
+
 .home {
   padding: 1rem;
+
+  @include respond(md) {
+    padding: 2rem;
+  }
+
+  @include respond(lg) {
+    padding: 3rem;
+  }
 
   .banner {
     position: relative;
@@ -13,6 +23,14 @@
       width: 100%;
       height: 200px;
       object-fit: cover;
+
+      @include respond(md) {
+        height: 260px;
+      }
+
+      @include respond(lg) {
+        height: 320px;
+      }
     }
 
     .banner-text {
@@ -25,11 +43,19 @@
       h3 {
         font-size: 1.5rem;
         font-weight: bold;
+
+        @include respond(lg) {
+          font-size: 1.8rem;
+        }
       }
 
       p {
         font-size: 1rem;
         margin-top: 0.25rem;
+
+        @include respond(lg) {
+          font-size: 1.1rem;
+        }
       }
     }
   }
@@ -40,6 +66,10 @@
     h2 {
       margin-bottom: 1rem;
       font-size: 1.5rem;
+
+      @include respond(lg) {
+        font-size: 1.75rem;
+      }
     }
 
     .card {
@@ -55,6 +85,10 @@
         width: 100%;
         height: 150px;
         object-fit: cover;
+
+        @include respond(lg) {
+          height: 180px;
+        }
       }
 
       .card-info {

--- a/src/pages/LandingPage/LandingPage.scss
+++ b/src/pages/LandingPage/LandingPage.scss
@@ -10,15 +10,33 @@
   background: linear-gradient(to bottom right, #eef5f9, #ffffff);
   text-align: center;
 
+  @include respond(md) {
+    padding: 4rem;
+  }
+
+  @include respond(lg) {
+    padding: 6rem;
+  }
+
   .content {
     max-width: 600px;
     width: 100%;
     animation: fadeIn 1s ease-out;
 
+    @include respond(md) {
+      max-width: 700px;
+      text-align: left;
+    }
+
     .logo {
       width: 120px;
       margin: 0 auto 1.5rem;
       display: block;
+
+      @include respond(lg) {
+        width: 160px;
+        margin: 0 0 1.5rem;
+      }
     }
 
     h1 {
@@ -49,6 +67,10 @@
       @media (min-width: 600px) {
         flex-direction: row;
         justify-content: center;
+      }
+
+      @include respond(md) {
+        justify-content: flex-start;
       }
 
       button {

--- a/src/pages/LoginPage/LoginPage.scss
+++ b/src/pages/LoginPage/LoginPage.scss
@@ -3,11 +3,65 @@
 
 .login-page {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   padding: 2rem;
   min-height: 100vh;
   background: linear-gradient(to bottom right, #f0f6fb, #ffffff);
+
+  .info-panel {
+    display: none;
+  }
+
+  @include respond(md) {
+    flex-direction: row;
+    gap: 4rem;
+
+    .info-panel {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      max-width: 320px;
+      text-align: left;
+
+      img {
+        width: 120px;
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 1.8rem;
+        margin-bottom: 0.5rem;
+      }
+
+      p {
+        color: #555;
+      }
+    }
+
+    .form-card {
+      max-width: 420px;
+    }
+  }
+
+  @include respond(lg) {
+    gap: 6rem;
+
+    .info-panel {
+      img {
+        width: 140px;
+      }
+
+      h1 {
+        font-size: 2rem;
+      }
+    }
+
+    .form-card {
+      max-width: 480px;
+    }
+  }
 
   .form-card {
     width: 100%;

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -52,6 +52,11 @@ const LoginPage = () => {
 
   return (
     <div className="login-page">
+      <div className="info-panel">
+        <img src={logo} alt="Manacity Logo" onError={(e) => (e.currentTarget.src = fallbackImage)} />
+        <h1>Welcome back!</h1>
+        <p>Sign in to continue exploring your city.</p>
+      </div>
       <motion.div
         className="form-card"
         initial={{ opacity: 0, y: 30 }}

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,0 +1,20 @@
+body {
+  font-family: system-ui, sans-serif;
+  color: #111;
+  background-color: #fff;
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+p {
+  margin-bottom: 1rem;
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -14,3 +14,23 @@
     transform: translateY(-2px);
   }
 }
+
+@mixin respond($breakpoint) {
+  @if $breakpoint == sm {
+    @media (min-width: 480px) {
+      @content;
+    }
+  } @else if $breakpoint == md {
+    @media (min-width: 768px) {
+      @content;
+    }
+  } @else if $breakpoint == lg {
+    @media (min-width: 1024px) {
+      @content;
+    }
+  } @else if $breakpoint == xl {
+    @media (min-width: 1280px) {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `respond` mixin for common breakpoints
- switch tab layout to sidebar navigation on larger screens
- tweak landing page and home page styles with breakpoints
- redesign login page with an info panel on desktop
- introduce basic typography rules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing packages and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685e5d921f288332b9811712eefd565c