### PR TITLE
Add react-slick module declaration

### DIFF
--- a/src/types/react-slick.d.ts
+++ b/src/types/react-slick.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-slick';


### PR DESCRIPTION
## Summary
- add custom TypeScript declaration for `react-slick`

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f9efc40308332a94600764221322e