### PR TITLE
Display logo and cart in desktop sidebar

### DIFF
--- a/src/layouts/TabLayout.scss
+++ b/src/layouts/TabLayout.scss
@@ -101,11 +101,22 @@
     }
   }
 
+  .desktop-extras {
+    display: none;
+  }
+
   @include respond(md) {
     flex-direction: row;
 
+    .floating-cart {
+      display: none;
+    }
+
     .top-header {
       margin-left: 220px;
+      .logo {
+        display: none;
+      }
     }
 
     .tab-content {
@@ -125,6 +136,47 @@
       border-top: none;
       border-right: none;
       padding: 1rem 0;
+
+      .desktop-extras {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        width: 100%;
+        padding: 0 1rem 1rem;
+      }
+
+      .sidebar-logo {
+        font-size: 1.25rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .sidebar-cart {
+        position: relative;
+        background: $primary-color;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        width: 100%;
+        height: 42px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.2rem;
+        cursor: pointer;
+
+        .count {
+          position: absolute;
+          top: -5px;
+          right: -5px;
+          background: red;
+          color: white;
+          font-size: 0.75rem;
+          padding: 2px 6px;
+          border-radius: 999px;
+        }
+      }
 
       button {
         flex-direction: row;

--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -73,10 +73,24 @@ const TabLayout = () => {
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.4 }}
       >
+        <div className="desktop-extras">
+          <h1 className="sidebar-logo" onClick={() => navigate('/home')}>
+            Manacity
+          </h1>
+          {cartItems.length > 0 && (
+            <button
+              className="sidebar-cart"
+              onClick={() => navigate('/cart')}
+            >
+              <FaShoppingCart />
+              <span className="count">{cartItems.length}</span>
+            </button>
+          )}
+        </div>
         {tabs.map((tab) => (
           <button
             key={tab.name}
-            className={location.pathname === tab.path ? "active" : ""}
+            className={location.pathname === tab.path ? 'active' : ''}
             onClick={() => navigate(tab.path)}
           >
             {tab.icon}


### PR DESCRIPTION
## Summary
- add desktop sidebar extras with logo and cart
- hide floating cart and header logo on desktop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68628cb1c3b08332a0940d4f7a3f6591