### PR TITLE
Add settings modal and theme system

### DIFF
--- a/src/components/SettingsModal/SettingsModal.module.scss
+++ b/src/components/SettingsModal/SettingsModal.module.scss
@@ -1,0 +1,52 @@
+@import '../../styles/variables';
+@import '../../styles/mixins';
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1100;
+
+  .modalContent {
+    @include glass-card;
+    padding: 2rem;
+    width: 90%;
+    max-width: 320px;
+    text-align: center;
+    position: relative;
+
+    .closeBtn {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      background: none;
+      border: none;
+      font-size: 1.25rem;
+      cursor: pointer;
+    }
+
+    .themeOptions {
+      display: flex;
+      justify-content: space-around;
+      margin: 1rem 0 1.5rem;
+
+      button {
+        @include button-style(#eee, #333);
+        padding: 0.4rem 0.8rem;
+
+        &.active {
+          background: $primary-color;
+          color: #fff;
+        }
+      }
+    }
+
+    .logoutBtn {
+      @include button-style(#e74c3c, #fff);
+      width: 100%;
+    }
+  }
+}

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -1,0 +1,64 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { AiOutlineClose } from 'react-icons/ai';
+import { useTheme } from '../../hooks/useTheme';
+import styles from './SettingsModal.module.scss';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onLogout: () => void;
+}
+
+const SettingsModal = ({ open, onClose, onLogout }: Props) => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className={styles.modal}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className={styles.modalContent}
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0.8 }}
+          >
+            <button className={styles.closeBtn} onClick={onClose}>
+              <AiOutlineClose />
+            </button>
+            <h3>Settings</h3>
+            <div className={styles.themeOptions}>
+              <button
+                onClick={() => setTheme('light')}
+                className={theme === 'light' ? styles.active : ''}
+              >
+                Light
+              </button>
+              <button
+                onClick={() => setTheme('dark')}
+                className={theme === 'dark' ? styles.active : ''}
+              >
+                Dark
+              </button>
+              <button
+                onClick={() => setTheme('colored')}
+                className={theme === 'colored' ? styles.active : ''}
+              >
+                Colored
+              </button>
+            </div>
+            <button className={styles.logoutBtn} onClick={onLogout}>
+              Logout
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default SettingsModal;

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark' | 'colored';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const getStoredTheme = (): Theme => {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark' || stored === 'colored') return stored;
+  return 'colored';
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>(getStoredTheme());
+
+  useEffect(() => {
+    document.body.classList.remove('theme-light', 'theme-dark', 'theme-colored');
+    document.body.classList.add(`theme-${theme}`);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/src/layouts/TabLayout.scss
+++ b/src/layouts/TabLayout.scss
@@ -73,8 +73,8 @@
 
   .floating-cart {
     position: fixed;
-    top: 1.2rem;
-    right: 1.2rem;
+    bottom: 6rem;
+    left: 1.2rem;
     background: $primary-color;
     color: #fff;
     border: none;
@@ -99,6 +99,25 @@
       padding: 2px 6px;
       border-radius: 999px;
     }
+  }
+
+  .floating-special {
+    position: fixed;
+    bottom: 6rem;
+    right: 1.2rem;
+    background: $primary-color;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 52px;
+    height: 52px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.4rem;
+    cursor: pointer;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
   }
 
   .desktop-extras {

--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -28,7 +28,6 @@ const TabLayout = () => {
       path: "/verified-users",
     },
     { name: "Events", icon: <AiOutlineCalendar />, path: "/events" },
-    { name: "Special", icon: <AiOutlineGift />, path: "/special-shop" },
   ];
 
   useEffect(() => {
@@ -64,6 +63,18 @@ const TabLayout = () => {
         >
           <FaShoppingCart />
           <span className="count">{cartItems.length}</span>
+        </motion.button>
+      )}
+
+      {/* Floating Special Offers */}
+      {location.pathname !== '/special-shop' && (
+        <motion.button
+          className="floating-special"
+          onClick={() => navigate('/special-shop')}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          <AiOutlineGift />
         </motion.button>
       )}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,11 +7,14 @@ import 'slick-carousel/slick/slick-theme.css'
 import './styles/main.scss';
 import App from './App.tsx'
 import { store } from './store'
+import { ThemeProvider } from './hooks/useTheme'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </Provider>
   </StrictMode>,
 )

--- a/src/pages/Profile/Profile.module.scss
+++ b/src/pages/Profile/Profile.module.scss
@@ -19,6 +19,18 @@
     align-items: center;
     text-align: center;
     gap: 0.5rem;
+    position: relative;
+
+    .settingsBtn {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      background: none;
+      border: none;
+      font-size: 1.4rem;
+      cursor: pointer;
+      color: #555;
+    }
   }
 
   .avatar {

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { motion, AnimatePresence } from 'framer-motion';
+import { AiOutlineSetting } from 'react-icons/ai';
+import SettingsModal from '../../components/SettingsModal/SettingsModal';
 import type { RootState } from '../../store';
 import { setUser, clearUser } from '../../store/slices/userSlice';
 import {
@@ -42,6 +44,7 @@ const Profile = () => {
   const [showVerifyModal, setShowVerifyModal] = useState(false);
   const [verifyForm, setVerifyForm] = useState({ profession: '', bio: '' });
   const [showBusinessModal, setShowBusinessModal] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [businessForm, setBusinessForm] = useState({
     name: '',
     category: '',
@@ -188,6 +191,13 @@ const Profile = () => {
   return (
     <div className={styles.profile}>
       <motion.div className={styles.header} initial={{ opacity: 0, y: 30 }} animate={{ opacity: 1, y: 0 }}>
+        <motion.button
+          className={styles.settingsBtn}
+          onClick={() => setShowSettings(true)}
+          whileHover={{ rotate: 90 }}
+        >
+          <AiOutlineSetting />
+        </motion.button>
         <img className={styles.avatar} src={avatar} alt={user.name} />
         <h2>{user.name}</h2>
         <span className={styles.roleBadge}>{user.role}</span>
@@ -216,9 +226,6 @@ const Profile = () => {
               Request Business
             </motion.button>
           )}
-          <motion.button className={styles.logout} whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.96 }} onClick={handleLogout}>
-            Logout
-          </motion.button>
         </div>
       </motion.div>
 
@@ -407,6 +414,12 @@ const Profile = () => {
           </div>
         </div>
       )}
+
+      <SettingsModal
+        open={showSettings}
+        onClose={() => setShowSettings(false)}
+        onLogout={handleLogout}
+      />
     </div>
   );
 };

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,7 +1,5 @@
 body {
   font-family: $font-body;
-  color: #111;
-  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
   min-height: 100vh;
   line-height: 1.5;
 }

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -1,0 +1,16 @@
+@import './variables';
+
+body.theme-light {
+  background: #f5f5f5;
+  color: #111;
+}
+
+body.theme-dark {
+  background: #111;
+  color: #f5f5f5;
+}
+
+body.theme-colored {
+  background: linear-gradient(135deg, $gradient-start, $gradient-middle, $gradient-end);
+  color: #111;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,7 @@
 @import "./variables";
 @import "./mixins";
 @import "./base";
+@import "./themes";
 @import "./shimmer";
 
 html,


### PR DESCRIPTION
## Summary
- implement theme provider with `useTheme`
- add animated settings modal
- enable theme selection and logout in modal
- reposition floating cart button
- add floating special offers button
- support global theming with new SCSS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module '@reduxjs/toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_6864dc6cfc9c8332a14ea6d94a7ae111