### PR TITLE
Add settings button and floating special shop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import EventDetails from './pages/EventDetails/EventDetails';
 import VerifiedUserDetails from './pages/VerifiedUserDetails/VerifiedUserDetails';
 import VerifiedUsers from './pages/VerifiedUsers/VerifiedUsers';
 import SpecialShop from './pages/SpecialShop/SpecialShop';
+import Settings from './pages/Settings/Settings';
 import Cart from './pages/Cart/Cart';
 import Events from './pages/Events/Events';
 import TabLayout from './layouts/TabLayout';
@@ -51,6 +52,7 @@ function App() {
             <Route path="/events" element={<Events />} />
             <Route path="/special-shop" element={<SpecialShop />} />
             <Route path="/profile" element={<Profile />} />
+            <Route path="/settings" element={<Settings />} />
           </Route>
           <Route path="/shops/:id" element={<ShopDetails />} />
           <Route path="/product/:id" element={<ProductDetails />} />

--- a/src/layouts/TabLayout.scss
+++ b/src/layouts/TabLayout.scss
@@ -23,12 +23,30 @@
       cursor: pointer;
     }
 
-    .profile-btn {
-      background: none;
-      border: none;
-      font-size: 1.5rem;
-      cursor: pointer;
-      color: #555;
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+
+      button {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: #555;
+        position: relative;
+
+        .count {
+          position: absolute;
+          top: -5px;
+          right: -5px;
+          background: red;
+          color: white;
+          font-size: 0.75rem;
+          padding: 2px 6px;
+          border-radius: 999px;
+        }
+      }
     }
   }
 
@@ -71,9 +89,10 @@
     }
   }
 
-  .floating-cart {
+
+  .special-shop-btn {
     position: fixed;
-    top: 1.2rem;
+    bottom: 4.5rem;
     right: 1.2rem;
     background: $primary-color;
     color: #fff;
@@ -88,17 +107,6 @@
     cursor: pointer;
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-
-    .count {
-      position: absolute;
-      top: -5px;
-      right: -5px;
-      background: red;
-      color: white;
-      font-size: 0.75rem;
-      padding: 2px 6px;
-      border-radius: 999px;
-    }
   }
 
   .desktop-extras {
@@ -108,9 +116,10 @@
   @include respond(md) {
     flex-direction: row;
 
-    .floating-cart {
-      display: none;
+    .special-shop-btn {
+      bottom: 1.2rem;
     }
+
 
     .top-header {
       display: none;
@@ -180,6 +189,20 @@
       }
 
       .sidebar-profile {
+        background: $primary-color;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        width: 100%;
+        height: 42px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.2rem;
+        cursor: pointer;
+      }
+
+      .sidebar-settings {
         background: $primary-color;
         color: #fff;
         border: none;

--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -10,6 +10,7 @@ import {
   AiOutlineGift,
   AiOutlineCalendar,
   AiOutlineUser,
+  AiOutlineSetting,
 } from "react-icons/ai";
 import { FaShoppingCart } from "react-icons/fa";
 import "./TabLayout.scss";
@@ -28,7 +29,6 @@ const TabLayout = () => {
       path: "/verified-users",
     },
     { name: "Events", icon: <AiOutlineCalendar />, path: "/events" },
-    { name: "Special", icon: <AiOutlineGift />, path: "/special-shop" },
   ];
 
   useEffect(() => {
@@ -43,29 +43,43 @@ const TabLayout = () => {
         animate={{ opacity: 1, y: 0 }}
       >
         <h1 className="logo" onClick={() => navigate('/home')}>Manacity</h1>
-        <button
-          className="profile-btn"
-          onClick={() => navigate('/profile')}
-        >
-          <AiOutlineUser />
-        </button>
+        <div className="actions">
+          {cartItems.length > 0 && (
+            <button
+              className="cart-btn"
+              onClick={() => navigate('/cart')}
+            >
+              <FaShoppingCart />
+              <span className="count">{cartItems.length}</span>
+            </button>
+          )}
+          <button
+            className="profile-btn"
+            onClick={() => navigate('/profile')}
+          >
+            <AiOutlineUser />
+          </button>
+          <button
+            className="settings-btn"
+            onClick={() => navigate('/settings')}
+          >
+            <AiOutlineSetting />
+          </button>
+        </div>
       </motion.header>
       <main className="tab-content">
         <Outlet />
       </main>
 
-      {/* Floating Cart */}
-      {cartItems.length > 0 && (
-        <motion.button
-          className="floating-cart"
-          onClick={() => navigate("/cart")}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-        >
-          <FaShoppingCart />
-          <span className="count">{cartItems.length}</span>
-        </motion.button>
-      )}
+
+      <motion.button
+        className="special-shop-btn"
+        onClick={() => navigate('/special-shop')}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
+        <AiOutlineGift />
+      </motion.button>
 
       <motion.nav
         className="tab-bar"
@@ -77,22 +91,28 @@ const TabLayout = () => {
           <h1 className="sidebar-logo" onClick={() => navigate('/home')}>
             Manacity
           </h1>
-          {cartItems.length > 0 && (
-            <button
-              className="sidebar-cart"
-              onClick={() => navigate('/cart')}
-            >
-              <FaShoppingCart />
-              <span className="count">{cartItems.length}</span>
-            </button>
-          )}
+        {cartItems.length > 0 && (
           <button
-            className="sidebar-profile"
-            onClick={() => navigate('/profile')}
+            className="sidebar-cart"
+            onClick={() => navigate('/cart')}
           >
-            <AiOutlineUser />
+            <FaShoppingCart />
+            <span className="count">{cartItems.length}</span>
           </button>
-        </div>
+        )}
+        <button
+          className="sidebar-profile"
+          onClick={() => navigate('/profile')}
+        >
+          <AiOutlineUser />
+        </button>
+        <button
+          className="sidebar-settings"
+          onClick={() => navigate('/settings')}
+        >
+          <AiOutlineSetting />
+        </button>
+      </div>
         {tabs.map((tab) => (
           <button
             key={tab.name}

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -1,0 +1,6 @@
+.settings {
+  padding: 1rem;
+  h2 {
+    margin-bottom: 0.5rem;
+  }
+}

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion';
+import './Settings.scss';
+
+const Settings = () => (
+  <motion.div
+    className="settings"
+    initial={{ opacity: 0, y: 30 }}
+    animate={{ opacity: 1, y: 0 }}
+  >
+    <h2>Settings</h2>
+    <p>Manage your app preferences here.</p>
+  </motion.div>
+);
+
+export default Settings;


### PR DESCRIPTION
## Summary
- modernize TabLayout UI with profile, cart, settings icons in the header
- drop bottom bar special tab and create floating `Special Shop` button
- keep sidebar actions for cart, profile and new settings
- create a placeholder Settings page and route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_68654899d24c8332bf8b9f3b76ec9f08