### PR TITLE
Add voice ordering interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import SpecialShop from './pages/SpecialShop/SpecialShop';
 import Settings from './pages/Settings/Settings';
 import Cart from './pages/Cart/Cart';
 import Events from './pages/Events/Events';
+import VoiceOrder from './pages/VoiceOrder/VoiceOrder';
 import TabLayout from './layouts/TabLayout';
 import { setUser } from './store/slices/userSlice';
 import type { AppDispatch } from './store';
@@ -51,6 +52,7 @@ function App() {
             <Route path="/verified-users" element={<VerifiedUsers />} />
             <Route path="/events" element={<Events />} />
             <Route path="/special-shop" element={<SpecialShop />} />
+            <Route path="/voice-order" element={<VoiceOrder />} />
             <Route path="/profile" element={<Profile />} />
             <Route path="/settings" element={<Settings />} />
           </Route>

--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -12,7 +12,7 @@ import {
   AiOutlineUser,
   AiOutlineSetting,
 } from "react-icons/ai";
-import { FaShoppingCart } from "react-icons/fa";
+import { FaShoppingCart, FaMicrophone } from "react-icons/fa";
 import "./TabLayout.scss";
 
 const TabLayout = () => {
@@ -29,6 +29,7 @@ const TabLayout = () => {
       path: "/verified-users",
     },
     { name: "Events", icon: <AiOutlineCalendar />, path: "/events" },
+    { name: "Order Now", icon: <FaMicrophone />, path: "/voice-order" },
   ];
 
   useEffect(() => {

--- a/src/pages/VoiceOrder/VoiceOrder.module.scss
+++ b/src/pages/VoiceOrder/VoiceOrder.module.scss
@@ -1,0 +1,78 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.voiceOrder {
+  padding: 2rem;
+  text-align: center;
+
+  h2 {
+    font-size: 1.6rem;
+    margin-bottom: 1rem;
+  }
+
+  .mic-wrapper {
+    margin: 2rem auto;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: $primary-color;
+    color: #fff;
+    font-size: 3rem;
+    cursor: pointer;
+  }
+
+  .listening {
+    animation: pulse 1.2s infinite ease-in-out;
+  }
+
+  .transcript {
+    margin-top: 1rem;
+    font-size: 1rem;
+    color: #333;
+    min-height: 1.5rem;
+  }
+
+  .results {
+    margin-top: 2rem;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  .product-card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    h4 {
+      margin: 0.5rem 0;
+    }
+
+    p {
+      margin: 0.25rem 0;
+    }
+
+    button {
+      margin-top: 0.5rem;
+      padding: 0.4rem 0.75rem;
+      background: $primary-color;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+  }
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}

--- a/src/pages/VoiceOrder/VoiceOrder.tsx
+++ b/src/pages/VoiceOrder/VoiceOrder.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { motion } from 'framer-motion';
+import { FaMicrophone } from 'react-icons/fa';
+import api from '../../api/client';
+import { sampleShops } from '../../data/sampleData';
+import type { RootState } from '../../store';
+import styles from './VoiceOrder.module.scss';
+
+interface Product {
+  _id: string;
+  name: string;
+  price: number;
+  image?: string;
+}
+
+interface Shop {
+  _id: string;
+  name: string;
+  products: Product[];
+}
+
+interface MatchedItem {
+  product: Product;
+  shop: Shop;
+  quantity: number;
+}
+
+const VoiceOrder = () => {
+  const user = useSelector((state: RootState) => state.user as any);
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [transcript, setTranscript] = useState('');
+  const [listening, setListening] = useState(false);
+  const [matched, setMatched] = useState<MatchedItem[]>([]);
+  const [language, setLanguage] = useState('en-US');
+  const recognitionRef = useRef<any>(null);
+
+  useEffect(() => {
+    api
+      .get('/shops')
+      .then((res) => {
+        if (Array.isArray(res.data) && res.data.length > 0) {
+          setShops(res.data);
+        } else {
+          setShops(sampleShops as unknown as Shop[]);
+        }
+      })
+      .catch(() => setShops(sampleShops as unknown as Shop[]));
+  }, []);
+
+  const startListening = () => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      alert('Speech recognition not supported');
+      return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.lang = language;
+    recognition.interimResults = true;
+    recognition.onresult = (e: any) => {
+      const text = Array.from(e.results)
+        .map((r: any) => r[0].transcript)
+        .join(' ');
+      setTranscript(text);
+    };
+    recognition.onend = () => {
+      setListening(false);
+      if (transcript) processTranscript(transcript);
+    };
+    recognitionRef.current = recognition;
+    recognition.start();
+    setListening(true);
+    setTranscript('');
+    setMatched([]);
+  };
+
+  const processTranscript = (text: string) => {
+    const items: MatchedItem[] = [];
+    const lower = text.toLowerCase();
+    shops.forEach((shop) => {
+      shop.products.forEach((product) => {
+        if (lower.includes(product.name.toLowerCase())) {
+          const regex = new RegExp(`(\\d+)\\s*${product.name}`, 'i');
+          const match = lower.match(regex);
+          const quantity = match ? parseInt(match[1], 10) : 1;
+          items.push({ product, shop, quantity });
+        }
+      });
+    });
+    setMatched(items);
+  };
+
+  const handleOrder = async (item: MatchedItem) => {
+    try {
+      await api.post('/orders/place', {
+        userId: user._id,
+        productId: item.product._id,
+        quantity: item.quantity,
+        shopId: item.shop._id,
+        source: 'voice-order',
+      });
+      await api.post('/orders/interest', {
+        shopId: item.shop._id,
+        productId: item.product._id,
+      });
+      alert('Order placed');
+    } catch {
+      alert('Failed to place order');
+    }
+  };
+
+  return (
+    <div className={styles.voiceOrder}>
+      <h2>Voice Order</h2>
+      <p>Tap to speak your order (e.g., "2 chicken biryani from Star Hotel")</p>
+      <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+        <option value="en-US">English</option>
+        <option value="hi-IN">Hindi</option>
+        <option value="te-IN">Telugu</option>
+      </select>
+      <motion.div
+        className={`${styles['mic-wrapper']} ${listening ? styles.listening : ''}`}
+        whileTap={{ scale: 0.9 }}
+        onClick={startListening}
+      >
+        <FaMicrophone />
+      </motion.div>
+      <div className={styles.transcript}>{transcript}</div>
+      <div className={styles.results}>
+        {matched.map((m) => (
+          <motion.div key={m.product._id} className={styles['product-card']} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            <h4>{m.product.name}</h4>
+            <p>Qty: {m.quantity}</p>
+            <p>₹{m.product.price}</p>
+            <p>{m.shop.name}</p>
+            <button onClick={() => handleOrder(m)}>Order</button>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default VoiceOrder;


### PR DESCRIPTION
## Summary
- add Order Now tab in navigation
- create VoiceOrder page with speech recognition and product matching
- wire up new route in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies during TypeScript compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68654be8cc788332be68afac96e9340a