### PR TITLE
Fix duplicate Order Now in bottom nav

### DIFF
--- a/src/layouts/TabLayout.tsx
+++ b/src/layouts/TabLayout.tsx
@@ -23,14 +23,12 @@ const TabLayout = () => {
   const tabs = [
     { name: "Home", icon: <AiFillHome />, path: "/home" },
     { name: "Shops", icon: <AiOutlineShop />, path: "/shops" },
-    { name: "Order Now", icon: <FaMicrophone />, path: "/voice-order" },
     {
       name: "Verified",
       icon: <AiOutlineUsergroupAdd />,
       path: "/verified-users",
     },
     { name: "Events", icon: <AiOutlineCalendar />, path: "/events" },
-    { name: "Order Now", icon: <FaMicrophone />, path: "/voice-order" },
   ];
 
   const orderTab = {
@@ -122,7 +120,6 @@ const TabLayout = () => {
         </button>
       </div>
         {tabs.slice(0, 2).map((tab) => (
-
           <button
             key={tab.name}
             className={location.pathname === tab.path ? 'active' : ''}
@@ -142,7 +139,6 @@ const TabLayout = () => {
           <span>{orderTab.name}</span>
         </button>
         {tabs.slice(2).map((tab) => (
-
           <button
             key={tab.name}
             className={location.pathname === tab.path ? 'active' : ''}
@@ -150,28 +146,6 @@ const TabLayout = () => {
           >
             {tab.icon}
             <span>{tab.name}</span>
-          </button>
-        ))}
-        <button
-          className={`order-now ${
-            location.pathname === '/voice-order' ? 'active' : ''
-          }`}
-          onClick={() => navigate('/voice-order')}
-        >
-          <FaMicrophone />
-        </button>
-        {tabs.slice(2).map((tab) => (
-          <button
-            key={tab.name}
-            className={
-              `${location.pathname === tab.path ? 'active' : ''} ${
-                tab.path === '/voice-order' ? 'order-now' : ''
-              }`
-            }
-            onClick={() => navigate(tab.path)}
-          >
-            {tab.icon}
-            {tab.path !== '/voice-order' && <span>{tab.name}</span>}
           </button>
         ))}
       </motion.nav>


### PR DESCRIPTION
## Summary
- remove duplicate Order Now tab entry
- simplify bottom nav rendering to show a single Order Now button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686557cc4a3c8332b1405a0cf3119075